### PR TITLE
Remove invalid -e option from backup.sh.

### DIFF
--- a/bin/backup.sh
+++ b/bin/backup.sh
@@ -26,7 +26,7 @@ chmod +x ./awscli-bundle/install
 
 BACKUP_FILE_NAME="$(date +"%Y-%m-%d-%H-%M")-$APP-$DATABASE.dump"
 
-/app/vendor/heroku-toolbelt/bin/heroku pg:backups capture $DATABASE -e --app $APP
+/app/vendor/heroku-toolbelt/bin/heroku pg:backups capture $DATABASE --app $APP
 curl -o $BACKUP_FILE_NAME `/app/vendor/heroku-toolbelt/bin/heroku pg:backups public-url --app $APP`
 gzip $BACKUP_FILE_NAME
 /tmp/aws/bin/aws s3 cp $BACKUP_FILE_NAME.gz s3://$S3_BUCKET_PATH/$APP/$DATABASE/$BACKUP_FILE_NAME.gz


### PR DESCRIPTION
Fixes #6 by removing invalid -e option.