### PR TITLE
Update heroku buildpack multi link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Simple heroku app with a bash script for capturing heroku database backups and c
 ## Installation
 
 
-First create a project on heroku with the [heroku-buildpack-multi](https://github.com/ddollar/heroku-buildpack-multi).
+First create a project on heroku with the [heroku-buildpack-multi](https://github.com/heroku/heroku-buildpack-multi).
 
 ```
-heroku create my-database-backups --buildpack https://github.com/ddollar/heroku-buildpack-multi
+heroku create my-database-backups --buildpack https://github.com/heroku/heroku-buildpack-multi
 ```
 
 Next push this project to your heroku projects git repository.


### PR DESCRIPTION
This is now maintained by heroku and David Dollars version is deprecated and will be switched off on 1st Jan 2017