### PR TITLE
Add NOGZIP variable to be able to switch off gzip

### DIFF
--- a/bin/backup.sh
+++ b/bin/backup.sh
@@ -28,7 +28,11 @@ BACKUP_FILE_NAME="$(date +"%Y-%m-%d-%H-%M")-$APP-$DATABASE.dump"
 
 heroku pg:backups capture $DATABASE --app $APP
 curl -o $BACKUP_FILE_NAME `heroku pg:backups:url --app $APP`
-gzip $BACKUP_FILE_NAME
-/tmp/aws/bin/aws s3 cp $BACKUP_FILE_NAME.gz s3://$S3_BUCKET_PATH/$APP/$DATABASE/$BACKUP_FILE_NAME.gz
+if [[ -z "$NOGZIP" ]]; then
+  gzip $BACKUP_FILE_NAME
+  /tmp/aws/bin/aws s3 cp $BACKUP_FILE_NAME.gz s3://$S3_BUCKET_PATH/$APP/$DATABASE/$BACKUP_FILE_NAME.gz
+else
+  /tmp/aws/bin/aws s3 cp $BACKUP_FILE_NAME s3://$S3_BUCKET_PATH/$APP/$DATABASE/$BACKUP_FILE_NAME
+fi
 echo "backup $BACKUP_FILE_NAME complete"
 

--- a/bin/backup.sh
+++ b/bin/backup.sh
@@ -28,11 +28,14 @@ BACKUP_FILE_NAME="$(date +"%Y-%m-%d-%H-%M")-$APP-$DATABASE.dump"
 
 heroku pg:backups capture $DATABASE --app $APP
 curl -o $BACKUP_FILE_NAME `heroku pg:backups:url --app $APP`
+FINAL_FILE_NAME=$BACKUP_FILE_NAME
+
 if [[ -z "$NOGZIP" ]]; then
   gzip $BACKUP_FILE_NAME
-  /tmp/aws/bin/aws s3 cp $BACKUP_FILE_NAME.gz s3://$S3_BUCKET_PATH/$APP/$DATABASE/$BACKUP_FILE_NAME.gz
-else
-  /tmp/aws/bin/aws s3 cp $BACKUP_FILE_NAME s3://$S3_BUCKET_PATH/$APP/$DATABASE/$BACKUP_FILE_NAME
+  FINAL_FILE_NAME=$BACKUP_FILE_NAME.gz
 fi
-echo "backup $BACKUP_FILE_NAME complete"
+
+/tmp/aws/bin/aws s3 cp $FINAL_FILE_NAME s3://$S3_BUCKET_PATH/$APP/$DATABASE/$FINAL_FILE_NAME
+
+echo "backup $FINAL_FILE_NAME complete"
 


### PR DESCRIPTION
Hi @kbaum,
Thank you for the solution, it is very helpful. 
In our setup, we found that to restore backups using `heroku pg:backups:restore` it is better to have unzipped dump on S3. I'm adding that function by using $NOGZIP variable.