### PR TITLE
Added a test to see if the aws command is already installed.

### DIFF
--- a/bin/backup.sh
+++ b/bin/backup.sh
@@ -18,11 +18,17 @@ if [[ -z "$S3_BUCKET_PATH" ]]; then
   exit 1
 fi
 
-#install aws-cli
-curl https://s3.amazonaws.com/aws-cli/awscli-bundle.zip -o awscli-bundle.zip
-unzip awscli-bundle.zip
-chmod +x ./awscli-bundle/install
-./awscli-bundle/install -i /tmp/aws
+# install aws-cli
+#  - this will already exist if we're running the script manually from a dyno more than once
+
+aws_command="/tmp/aws/bin/aws"
+
+if [[ ! -f "${aws_command}" ]]; then
+  curl https://s3.amazonaws.com/aws-cli/awscli-bundle.zip -o awscli-bundle.zip
+  unzip awscli-bundle.zip
+  chmod +x ./awscli-bundle/install
+  ./awscli-bundle/install -i /tmp/aws
+fi
 
 BACKUP_FILE_NAME="$(date +"%Y-%m-%d-%H-%M")-$APP-$DATABASE.dump"
 
@@ -35,7 +41,7 @@ if [[ -z "$NOGZIP" ]]; then
   FINAL_FILE_NAME=$BACKUP_FILE_NAME.gz
 fi
 
-/tmp/aws/bin/aws s3 cp $FINAL_FILE_NAME s3://$S3_BUCKET_PATH/$APP/$DATABASE/$FINAL_FILE_NAME
+${aws_command} s3 cp $FINAL_FILE_NAME s3://$S3_BUCKET_PATH/$APP/$DATABASE/$FINAL_FILE_NAME
 
 echo "backup $FINAL_FILE_NAME complete"
 


### PR DESCRIPTION
Only install awscli if required. Useful when testing operation manually from a dyno ($ heroku run bash) as it only downloads awscli the first time backup.sh is run.