### PR TITLE
using aws cli v2 to add support for heroku-20

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Simple heroku app with a bash script for capturing heroku database backups and copying to your s3 bucket.  Deploy this as a separate app within heroku and schedule the script to backup your production databases which exist within another heroku project.
 
+Now using [aws cli v2](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2-linux.html) - works with both `heroku-18` and `heroku-20` stacks.
 
 ## Installation
 
@@ -82,4 +83,19 @@ You can add a `HEARTBEAT_URL` to the script so a request gets sent every time a 
 
 ```
 heroku config:add HEARTBEAT_URL=https://hearbeat.url -a my-database-backups
+```
+
+If you are using [heroku's scheduled backups](https://devcenter.heroku.com/articles/heroku-postgres-backups#scheduling-backups) you might only want to archive the latest
+backup to S3 for long-term storage. Set the `ONLY_CAPTURE_TO_S3` variable when running the command:
+
+```
+ONLY_CAPTURE_TO_S3=true APP=your-app DATABASE=HEROKU_POSTGRESQL_NAVY_URL /app/bin/backup.sh
+```
+
+#### Tip
+
+The default timezone is `UTC`. To use your [preferred timezone](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones) in the filename timestamp, set the `TZ` variable when calling the command:
+
+```
+TZ=America/Los_Angeles APP=your-app DATABASE=HEROKU_POSTGRESQL_NAVY_URL /app/bin/backup.sh
 ```


### PR DESCRIPTION
I've made several tweaks for my use-case - cherry-pick as you see fit!

1. Moved to aws cli v2 - now works with both heroku-18 and heroku-20 stacks 👍  - this would close #27  
1. I use heroku's scheduled backups for one database - this script is useful to archive the latest backup to S3 - added the ONLY_CAPTURE_TO_S3 flag to avoid capturing the database again - example usage in the README.md
1. I tweaked the file format to include the TZ and use underscores between some parts which I find more readable